### PR TITLE
Fixed the first bug

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/js/main.js
+++ b/js/main.js
@@ -19,7 +19,7 @@ let theButtons = document.querySelectorAll("#buttonHolder img"),
 // functionality always goes in the middle -> how do we want
 // the app to behave?
 function changeBGImage() {
-	// the `` is a JavaScript template string. It tells the JS enging to evaluate the expression
+	// the `` is a JavaScript template string. It tells the JS engine to evaluate the expression
 	// inside the braces - run that little bit of code. In this case it's just pulling the ID of the
 	// button we clicked on and putting it at the end of the image name (0, 1, 2, 3)
 	// and updating the background-image style of the puzzle board element.
@@ -45,7 +45,10 @@ function handleDrop(e) {
 	e.preventDefault();
 	console.log('dropped something on me');
 	// bug fix #1 should go here, and it's at most 3 lines of JS code
-
+	if (this.children.length > 0) {
+	// Move the existing piece back to the puzzle pieces container
+	puzzleBoard.appendChild(this.children[0]);
+	}
 	// this line is going to move the dragged piece from the left side of the board
 	// into whatever drop zone we choose. appendChild means "add element to the container"
 	this.appendChild(draggedPiece);


### PR DESCRIPTION
In this commit, i fixed the first bug in our code which caused users to be able to drag and drop more than one puzzle piece into a drop zone. I fixed it by adding an IF statement in the handleDrop function . The solution involved modifying the handleDrop function to check if the drop zone already contains a puzzle piece. If it does, the existing piece should be moved back to the puzzle pieces container before appending the new dragged piece. This ensures that each drop zone contains at most one puzzle piece.